### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/Bazel_Cpp_Template/security/code-scanning/1](https://github.com/gvatsal60/Bazel_Cpp_Template/security/code-scanning/1)

To fix the problem, we should add a `permissions` block with minimal required privileges. The best place is at the workflow root (just after the `name:` and before `on:` block), which will apply a default for all jobs (unless overridden). In this case, only read access to repository contents is required, so we set `permissions: contents: read`. No changes to steps or other logic are needed. This change reduces the risk by ensuring the workflow only gets the permissions needed for its own steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
