### PR TITLE
Remove build status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=gvatsal60_Bazel_Cpp_Template&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=gvatsal60_Bazel_Cpp_Template)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/9a0c920100564271a193f76ddd6bd829)](https://app.codacy.com/gh/gvatsal60/Bazel_Cpp_Template/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![CodeFactor](https://www.codefactor.io/repository/github/gvatsal60/bazel_cpp_template/badge)](https://www.codefactor.io/repository/github/gvatsal60/bazel_cpp_template)
-[![build status](https://github.com/gvatsal60/Bazel_Cpp_Template/actions/workflows/readme-checker.yaml/badge.svg)](https://github.com/gvatsal60/Bazel_Cpp_Template/actions/workflows/readme-checker.yaml)
 ![GitHub pull-requests](https://img.shields.io/github/issues-pr/gvatsal60/Bazel_Cpp_Template)
 ![GitHub Issues](https://img.shields.io/github/issues/gvatsal60/Bazel_Cpp_Template)
 ![GitHub forks](https://img.shields.io/github/forks/gvatsal60/Bazel_Cpp_Template)


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file by removing the build status badge for the `readme-checker.yaml` workflow, likely because the workflow is no longer relevant or needed.