### PR TITLE
Update Dockerfile.debug

### DIFF
--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -13,7 +13,7 @@
 # ##########################################################################
 # Base Image
 # ##########################################################################
-FROM mcr.microsoft.com/devcontainers/cpp:latest AS base
+FROM mcr.microsoft.com/devcontainers/cpp:debian AS base
 
 # Description of the purpose of this image
 LABEL DESCRIPTION="Build Environment"


### PR DESCRIPTION
This pull request updates the base image used in the `dockerfiles/Dockerfile.debug` file to improve compatibility and consistency with Debian-based environments.

Docker image update:

* Changed the base image from `mcr.microsoft.com/devcontainers/cpp:latest` to `mcr.microsoft.com/devcontainers/cpp:debian` in `dockerfiles/Dockerfile.debug` to explicitly use the Debian variant.