### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
       ],
       "settings": {
         "[cpp]": {
-          "editor.defaultFormatter": "ms-vscode.cpptools"
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
         "[dockercompose]": {
           "editor.autoIndent": "advanced",


### PR DESCRIPTION
This pull request makes a small update to the default code formatter for C++ files in the `.devcontainer/devcontainer.json` configuration. The formatter is switched from `ms-vscode.cpptools` to `llvm-vs-code-extensions.vscode-clangd`.