### PR TITLE
fix: reduce GitHub Actions permissions from write to read

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,14 +1,12 @@
 name: Build Project
 on:
   push:
-    branches: ["master"]
   pull_request:
-    branches: ["*"]
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # Grant write permissions to modify repository contents
     steps:
       - uses: actions/checkout@v7
       - name: Build


### PR DESCRIPTION
Changed `contents: write` to `contents: read` in the workflow to follow least privilege principle.